### PR TITLE
feat(captureSnapshot): add function to capture directory tree structure

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -164,7 +164,7 @@ export async function captureSnapshot(path: string): Promise<string> {
   const entries = await readdir(path, { recursive: true, withFileTypes: true });
 
   // pre calculate normalized base path
-  const normalizedBasePath = normalize(path.replace(/\/$/, ""));
+  const normalizedBasePath = normalize(path.replace(/[/\\]$/, ""));
   const basePathLength = normalizedBasePath.length;
 
   const tree = new Map<string, Array<{ name: string; isDir: boolean }>>();

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -46,8 +46,7 @@ import type {
   TestdirSymlink,
 } from "./types";
 import { readdir } from "node:fs/promises";
-import { platform } from "node:os";
-import { basename, join, normalize, sep } from "node:path";
+import { basename, join, normalize } from "node:path";
 import {
   FIXTURE_METADATA_SYMBOL,
   FIXTURE_TYPE_LINK_SYMBOL,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -204,7 +204,7 @@ export async function captureSnapshot(path: string): Promise<string> {
 
   // for debug only
   if (platform() === "win32") {
-    console.error("MAP:", JSON.stringify(tree, null, 2));
+    console.error("MAP:", Object.fromEntries(tree));
   }
 
   function renderTree(dirPath: string, prefix: string): void {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -164,13 +164,13 @@ export async function captureSnapshot(path: string): Promise<string> {
   const entries = await readdir(path, { recursive: true, withFileTypes: true });
 
   // pre calculate normalized base path
-  const normalizedBasePath = path.replace(/\/$/, "");
+  const normalizedBasePath = normalize(path.replace(/\/$/, ""));
   const basePathLength = normalizedBasePath.length;
 
   const tree = new Map<string, Array<{ name: string; isDir: boolean }>>();
 
   for (const entry of entries) {
-    const fullPath = join(entry.parentPath || "", entry.name);
+    const fullPath = normalize(join(entry.parentPath || "", entry.name));
     const relativePath = fullPath.slice(basePathLength + 1);
 
     const lastSlashIndex = relativePath.lastIndexOf("/");

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -47,7 +47,7 @@ import type {
 } from "./types";
 import { readdir } from "node:fs/promises";
 import { platform } from "node:os";
-import { basename, join, normalize } from "node:path";
+import { basename, join, normalize, sep } from "node:path";
 import {
   FIXTURE_METADATA_SYMBOL,
   FIXTURE_TYPE_LINK_SYMBOL,
@@ -174,7 +174,7 @@ export async function captureSnapshot(path: string): Promise<string> {
     const fullPath = normalize(join(entry.parentPath || "", entry.name));
     const relativePath = normalize(fullPath.slice(basePathLength + 1));
 
-    const lastSlashIndex = relativePath.lastIndexOf("/");
+    const lastSlashIndex = relativePath.lastIndexOf(sep);
     const parentDir = lastSlashIndex === -1 ? "" : relativePath.slice(0, lastSlashIndex);
 
     let children = tree.get(parentDir);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -172,9 +172,9 @@ export async function captureSnapshot(path: string): Promise<string> {
 
   for (const entry of entries) {
     const fullPath = normalize(join(entry.parentPath || "", entry.name));
-    const relativePath = normalize(fullPath.slice(basePathLength + 1));
+    const relativePath = normalize(fullPath.slice(basePathLength + 1)).replace(/\\/g, "/");
 
-    const lastSlashIndex = relativePath.lastIndexOf(sep);
+    const lastSlashIndex = relativePath.lastIndexOf("/");
     const parentDir = lastSlashIndex === -1 ? "" : relativePath.slice(0, lastSlashIndex);
 
     let children = tree.get(parentDir);
@@ -201,11 +201,6 @@ export async function captureSnapshot(path: string): Promise<string> {
   }
 
   const result: string[] = [`${basename(path)}/`];
-
-  // for debug only
-  if (platform() === "win32") {
-    console.error("MAP:", Object.fromEntries(tree));
-  }
 
   function renderTree(dirPath: string, prefix: string): void {
     const children = tree.get(dirPath);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -172,7 +172,7 @@ export async function captureSnapshot(path: string): Promise<string> {
 
   for (const entry of entries) {
     const fullPath = normalize(join(entry.parentPath || "", entry.name));
-    const relativePath = fullPath.slice(basePathLength + 1);
+    const relativePath = normalize(fullPath.slice(basePathLength + 1));
 
     const lastSlashIndex = relativePath.lastIndexOf("/");
     const parentDir = lastSlashIndex === -1 ? "" : relativePath.slice(0, lastSlashIndex);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -46,6 +46,7 @@ import type {
   TestdirSymlink,
 } from "./types";
 import { readdir } from "node:fs/promises";
+import { platform } from "node:os";
 import { basename, join, normalize } from "node:path";
 import {
   FIXTURE_METADATA_SYMBOL,
@@ -200,6 +201,11 @@ export async function captureSnapshot(path: string): Promise<string> {
   }
 
   const result: string[] = [`${basename(path)}/`];
+
+  // for debug only
+  if (platform() === "win32") {
+    console.error("MAP:", JSON.stringify(tree, null, 2));
+  }
 
   function renderTree(dirPath: string, prefix: string): void {
     const children = tree.get(dirPath);

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,4 +1,4 @@
-import { normalize } from "node:path";
+import { basename, normalize } from "node:path";
 import { describe, expect, it } from "vitest";
 import { FIXTURE_METADATA_SYMBOL, FIXTURE_TYPE_LINK_SYMBOL, FIXTURE_TYPE_SYMLINK_SYMBOL } from "../src/constants";
 import { captureSnapshot, hasMetadata, isLink, isPrimitive, isSymlink, link, metadata, symlink } from "../src/helpers";
@@ -228,7 +228,7 @@ describe("captureSnapshot", () => {
     await using dir = await testdir({});
 
     const result = await captureSnapshot(dir.path);
-    const dirName = normalize(dir.path).split("/").pop()!;
+    const dirName = basename(dir.path);
     expect(result).toBe(`${dirName}/`);
   });
 
@@ -238,7 +238,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = normalize(dir.path).split("/").pop()!;
+    const dirName = basename(dir.path);
 
     expect(result).toBe([
       `${dirName}/`,
@@ -254,7 +254,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = normalize(dir.path).split("/").pop()!;
+    const dirName = basename(dir.path);
 
     expect(result).toBe([
       `${dirName}/`,
@@ -273,7 +273,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = normalize(dir.path).split("/").pop()!;
+    const dirName = basename(dir.path);
 
     expect(result).toBe([
       `${dirName}/`,
@@ -304,7 +304,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = normalize(dir.path).split("/").pop()!;
+    const dirName = basename(dir.path);
 
     expect(result).toBe([
       `${dirName}/`,
@@ -334,7 +334,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = normalize(dir.path).split("/").pop()!;
+    const dirName = basename(dir.path);
 
     expect(result).toBe([
       `${dirName}/`,
@@ -354,7 +354,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = normalize(dir.path).split("/").pop()!;
+    const dirName = basename(dir.path);
 
     expect(result).toBe([
       `${dirName}/`,
@@ -377,7 +377,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = normalize(dir.path).split("/").pop()!;
+    const dirName = basename(dir.path);
 
     expect(result).toBe([
       `${dirName}/`,

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -228,7 +228,7 @@ describe("captureSnapshot", () => {
     await using dir = await testdir({});
 
     const result = await captureSnapshot(dir.path);
-    const dirName = dir.path.split("/").pop()!;
+    const dirName = normalize(dir.path).split("/").pop()!;
     expect(result).toBe(`${dirName}/`);
   });
 
@@ -238,7 +238,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = dir.path.split("/").pop()!;
+    const dirName = normalize(dir.path).split("/").pop()!;
 
     expect(result).toBe([
       `${dirName}/`,
@@ -254,7 +254,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = dir.path.split("/").pop()!;
+    const dirName = normalize(dir.path).split("/").pop()!;
 
     expect(result).toBe([
       `${dirName}/`,
@@ -273,7 +273,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = dir.path.split("/").pop()!;
+    const dirName = normalize(dir.path).split("/").pop()!;
 
     expect(result).toBe([
       `${dirName}/`,
@@ -304,7 +304,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = dir.path.split("/").pop()!;
+    const dirName = normalize(dir.path).split("/").pop()!;
 
     expect(result).toBe([
       `${dirName}/`,
@@ -334,7 +334,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = dir.path.split("/").pop()!;
+    const dirName = normalize(dir.path).split("/").pop()!;
 
     expect(result).toBe([
       `${dirName}/`,
@@ -354,7 +354,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = dir.path.split("/").pop()!;
+    const dirName = normalize(dir.path).split("/").pop()!;
 
     expect(result).toBe([
       `${dirName}/`,
@@ -377,7 +377,7 @@ describe("captureSnapshot", () => {
     });
 
     const result = await captureSnapshot(dir.path);
-    const dirName = dir.path.split("/").pop()!;
+    const dirName = normalize(dir.path).split("/").pop()!;
 
     expect(result).toBe([
       `${dirName}/`,


### PR DESCRIPTION
This PR implements a `captureSnapshot` function that will capture a directory path to a tree view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a capability to generate a readable ASCII tree-view snapshot of a directory, with deterministic ordering (directories first), support for deep nesting, and clear formatting for empty or invalid paths.

- **Tests**
  - Added comprehensive tests covering empty, single-file, nested, mixed, deeply nested, and complex directory layouts to ensure consistent snapshot output and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->